### PR TITLE
feat: Search input component; Debounced search (300ms); Case-insensit…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,22 @@
 'use client'
 
+import { useState } from 'react'
+
 import PokemonGrid from '@/components/PokemonGrid'
+import PokemonSearchResults from '@/components/PokemonSearchResults'
+import SearchBar from '@/components/SearchBar'
 
 export default function Home() {
+  const [selectedPokemon, setSelectedPokemon] = useState<{ id: number; name: string } | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+
   const handlePokemonClick = (pokemon: { id: number; name: string }) => {
-    // TODO: Implement pokemon detail modal or navigation
-    console.log('Clicked pokemon:', pokemon)
+    setSelectedPokemon(pokemon)
+    console.log('Selected Pokemon:', pokemon)
+  }
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query.trim())
   }
 
   return (
@@ -15,7 +26,31 @@ export default function Home() {
         <p className="text-gray-600">Discover and explore the world of Pokémon</p>
       </div>
 
-      <PokemonGrid onPokemonClick={handlePokemonClick} />
+      {/* Search Bar */}
+      <div className="mb-8">
+        <SearchBar
+          onSearch={handleSearch}
+          className="mx-auto max-w-md"
+        />
+      </div>
+
+      {/* Content - either search results or main grid */}
+      {searchQuery ? (
+        <PokemonSearchResults
+          query={searchQuery}
+          onPokemonClick={handlePokemonClick}
+        />
+      ) : (
+        <PokemonGrid onPokemonClick={handlePokemonClick} />
+      )}
+
+      {selectedPokemon && (
+        <div className="mt-8 rounded-lg bg-blue-50 p-4">
+          <p className="text-blue-800">
+            Selected: {selectedPokemon.name} (ID: {selectedPokemon.id})
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/PokemonSearchResults.tsx
+++ b/src/components/PokemonSearchResults.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { api } from '@/trpc/client'
+import { Loader2, Search } from 'lucide-react'
+
+import { PokemonSummary } from '@/lib/pokeapi'
+
+import PokemonCard from './PokemonCard'
+import { Button } from './ui/button'
+
+interface PokemonSearchResultsProps {
+  query: string
+  onPokemonClick?: (pokemon: { id: number; name: string }) => void
+}
+
+export default function PokemonSearchResults({ query, onPokemonClick }: PokemonSearchResultsProps) {
+  const { data, isLoading, error, refetch } = api.pokemon.search.useQuery(
+    { query, limit: 20 },
+    { enabled: query.length > 0 }
+  )
+
+  if (!query) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Search className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+        <h3 className="mb-2 text-lg font-medium text-gray-600">Search for Pokémon</h3>
+        <p className="text-sm text-gray-500">Enter a Pokémon name to start searching</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-blue-500" />
+          <p className="text-gray-600">Searching for &ldquo;{query}&rdquo;...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <p className="mb-4 text-red-600">Failed to search Pokémon</p>
+          <Button
+            onClick={() => refetch()}
+            variant="outline"
+          >
+            Try Again
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (data?.isEmpty) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Search className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+        <h3 className="mb-2 text-lg font-medium text-gray-600">No Pokémon found</h3>
+        <p className="text-sm text-gray-500">
+          No Pokémon match your search for &ldquo;{query}&rdquo;. Try a different name.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Search Results Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-600">
+          Found {data?.count} result{data?.count !== 1 ? 's' : ''} for &ldquo;{query}&rdquo;
+        </p>
+        {data?.hasMore && <p className="text-xs text-gray-500">Showing first 20 results</p>}
+      </div>
+
+      {/* Results Grid */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {data?.pokemon.map((pokemon: PokemonSummary, index: number) => (
+          <PokemonCard
+            key={pokemon.id}
+            pokemon={pokemon}
+            onClick={() => onPokemonClick?.(pokemon)}
+            priority={index < 6}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Search, X } from 'lucide-react'
+
+import { Button } from './ui/button'
+
+interface SearchBarProps {
+  onSearch: (query: string) => void
+  placeholder?: string
+  className?: string
+}
+
+export default function SearchBar({
+  onSearch,
+  placeholder = 'Search Pokémon...',
+  className = ''
+}: SearchBarProps) {
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+
+  // Debounce the search query by 300ms
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedQuery(query)
+    }, 300)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [query])
+
+  // Call onSearch when debounced query changes
+  useEffect(() => {
+    onSearch(debouncedQuery)
+  }, [debouncedQuery, onSearch])
+
+  const handleClear = () => {
+    setQuery('')
+  }
+
+  return (
+    <div className={`relative ${className}`}>
+      <div className="relative">
+        <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          className="w-full rounded-lg border border-gray-200 bg-white px-10 py-2 text-sm placeholder:text-gray-500 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+        />
+        {query && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            className="absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2 p-0 hover:bg-gray-100"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/server/api/routers/pokemon.ts
+++ b/src/server/api/routers/pokemon.ts
@@ -56,5 +56,29 @@ export const pokemonRouter = createTRPCRouter({
       console.error(`Failed to fetch pokemon ${input.nameOrId}:`, error)
       throw new Error(`Failed to fetch Pokémon ${input.nameOrId}`)
     }
-  })
+  }),
+
+  search: publicProcedure
+    .input(
+      z.object({
+        query: z.string().min(1, 'Search query is required'),
+        limit: z.number().min(1).max(50).default(20)
+      })
+    )
+    .query(async ({ input }) => {
+      try {
+        const result = await pokeAPI.searchPokemon(input.query, input.limit)
+
+        return {
+          pokemon: result.results,
+          count: result.count,
+          query: result.query,
+          hasMore: result.hasMore,
+          isEmpty: result.results.length === 0
+        }
+      } catch (error) {
+        console.error('Failed to search pokemon:', error)
+        throw new Error('Failed to search Pokémon')
+      }
+    })
 })


### PR DESCRIPTION
This pull request adds a Pokémon search feature to the app, allowing users to search for Pokémon by name and view search results in a dedicated component. The main changes include implementing a debounced search bar, a results display component with loading and error states, and backend support for searching Pokémon through the API and PokeAPI service.

**Frontend: Pokémon Search UI**

- Added a new `SearchBar` component with debounced input, clear button, and callback to trigger searches. (`src/components/SearchBar.tsx`)
- Introduced a `PokemonSearchResults` component to display search results, loading, empty, and error states, and handle Pokémon selection. (`src/components/PokemonSearchResults.tsx`)
- Updated the `Home` page to include the search bar and conditionally show either search results or the main Pokémon grid, and to display the selected Pokémon. (`src/app/page.tsx`) [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR3-R19) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR29-R53)

**Backend: Pokémon Search API**

- Added `PokemonSummary` and `PokemonSearchResponse` types, and implemented the `searchPokemon` method in `PokeAPIService` to filter and return Pokémon matching the search query, with caching and result limiting. (`src/lib/pokeapi.ts`) [[1]](diffhunk://#diff-472110cae98389b0c33df5073a1181dcddb464ac1f3d57480d00413244b20f51R47-R60) [[2]](diffhunk://#diff-472110cae98389b0c33df5073a1181dcddb464ac1f3d57480d00413244b20f51R120-R174)
- Added a new `search` endpoint to the `pokemon` TRPC router to expose the search functionality to the frontend, including validation, error handling, and result formatting. (`src/server/api/routers/pokemon.ts`)