### PR TITLE
feat: Favorites System

### DIFF
--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState } from 'react'
+
+import Link from 'next/link'
+
+import { api } from '@/trpc/client'
+import { Heart, Loader2 } from 'lucide-react'
+
+import FavoriteButton from '@/components/FavoriteButton'
+import LoginPrompt from '@/components/LoginPrompt'
+import PokemonCard from '@/components/PokemonCard'
+import PokemonDetailModal from '@/components/PokemonDetailModal'
+import { Button } from '@/components/ui/button'
+
+export default function FavoritesPage() {
+  const [selectedPokemon, setSelectedPokemon] = useState<{ id: number; name: string } | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false)
+
+  const {
+    data: favorites,
+    isLoading,
+    error,
+    refetch
+  } = api.favorites.list.useQuery(undefined, {
+    retry: (failureCount, error) => {
+      // Don't retry if unauthorized
+      if (error.data?.code === 'UNAUTHORIZED') {
+        setLoginPromptOpen(true)
+        return false
+      }
+      return failureCount < 3
+    }
+  })
+
+  const handlePokemonClick = (pokemon: { id: number; name: string }) => {
+    setSelectedPokemon(pokemon)
+    setModalOpen(true)
+  }
+
+  const handleModalClose = () => {
+    setModalOpen(false)
+    setSelectedPokemon(null)
+  }
+
+  const handleAuthRequired = () => {
+    setLoginPromptOpen(true)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold text-gray-900">My Favorites</h1>
+          <p className="text-gray-600">Your favorite Pokémon collection</p>
+        </div>
+
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-blue-500" />
+            <p className="text-gray-600">Loading your favorites...</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error?.data?.code === 'UNAUTHORIZED') {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold text-gray-900">My Favorites</h1>
+          <p className="text-gray-600">Your favorite Pokémon collection</p>
+        </div>
+
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Heart className="mx-auto mb-4 h-16 w-16 text-gray-300" />
+          <h2 className="mb-2 text-xl font-semibold text-gray-700">Login Required</h2>
+          <p className="mb-6 text-gray-600">
+            Please log in to view your favorite Pokémon collection.
+          </p>
+          <Button onClick={() => setLoginPromptOpen(true)}>Log In to Continue</Button>
+        </div>
+
+        <LoginPrompt
+          isOpen={loginPromptOpen}
+          onClose={() => setLoginPromptOpen(false)}
+          message="Log in to view and manage your favorite Pokémon!"
+        />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold text-gray-900">My Favorites</h1>
+          <p className="text-gray-600">Your favorite Pokémon collection</p>
+        </div>
+
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <p className="mb-4 text-red-600">Failed to load your favorites</p>
+            <Button
+              onClick={() => refetch()}
+              variant="outline"
+            >
+              Try Again
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!favorites?.favorites.length) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="mb-2 text-3xl font-bold text-gray-900">My Favorites</h1>
+          <p className="text-gray-600">Your favorite Pokémon collection</p>
+        </div>
+
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Heart className="mx-auto mb-4 h-16 w-16 text-gray-300" />
+          <h2 className="mb-2 text-xl font-semibold text-gray-700">No favorites yet</h2>
+          <p className="mb-6 text-gray-600">
+            Start exploring Pokémon and add them to your favorites collection!
+          </p>
+          <Button asChild>
+            <Link href="/">Explore Pokémon</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold text-gray-900">My Favorites</h1>
+        <p className="text-gray-600">{favorites.count} favorite Pokémon in your collection</p>
+      </div>
+
+      {/* Favorites Grid */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {favorites.favorites.map((pokemon) => {
+          // Convert the favorite data to match PokemonCard expected format
+          const pokemonData = {
+            id: parseInt(pokemon.id),
+            name: pokemon.name,
+            sprite: pokemon.sprite,
+            types: [] // We don't store types in favorites, so empty array
+          }
+
+          return (
+            <div
+              key={pokemon.id}
+              className="relative"
+            >
+              <PokemonCard
+                pokemon={pokemonData}
+                onClick={() => handlePokemonClick(pokemonData)}
+                priority={false}
+              />
+              {/* Favorite button overlay */}
+              <div className="absolute top-2 right-2">
+                <FavoriteButton
+                  pokemonId={pokemon.id}
+                  pokemonName={pokemon.name}
+                  pokemonSprite={pokemon.sprite}
+                  onAuthRequired={handleAuthRequired}
+                  size="sm"
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Pokemon Detail Modal */}
+      {selectedPokemon && (
+        <PokemonDetailModal
+          pokemonName={selectedPokemon.name}
+          isOpen={modalOpen}
+          onClose={handleModalClose}
+        />
+      )}
+
+      {/* Login Prompt */}
+      <LoginPrompt
+        isOpen={loginPromptOpen}
+        onClose={() => setLoginPromptOpen(false)}
+        message="Log in to manage your favorite Pokémon!"
+      />
+    </div>
+  )
+}

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState } from 'react'
+
+import { api } from '@/trpc/client'
+import { Heart, Loader2 } from 'lucide-react'
+
+import { Button } from './ui/button'
+
+interface FavoriteButtonProps {
+  pokemonId: string
+  pokemonName: string
+  pokemonSprite?: string
+  onAuthRequired?: () => void
+  size?: 'sm' | 'md' | 'lg'
+  variant?: 'icon' | 'full'
+  className?: string
+}
+
+export default function FavoriteButton({
+  pokemonId,
+  pokemonName,
+  pokemonSprite,
+  onAuthRequired,
+  size = 'md',
+  variant = 'icon',
+  className = ''
+}: FavoriteButtonProps) {
+  const [optimisticFavorited, setOptimisticFavorited] = useState<boolean | null>(null)
+  const utils = api.useUtils()
+
+  // Check if favorited
+  const { data: checkData, isLoading: isCheckingFavorite } = api.favorites.check.useQuery(
+    { pokemonId },
+    {
+      retry: false,
+      refetchOnWindowFocus: false
+    }
+  )
+
+  // Toggle favorite mutation
+  const toggleFavorite = api.favorites.toggle.useMutation({
+    onMutate: async () => {
+      // Cancel any outgoing refetches
+      await utils.favorites.check.cancel({ pokemonId })
+
+      // Snapshot the previous value
+      const previousData = utils.favorites.check.getData({ pokemonId })
+
+      // Optimistically update the UI
+      const currentFavorited = optimisticFavorited ?? previousData?.isFavorited ?? false
+      setOptimisticFavorited(!currentFavorited)
+
+      // Return a context object with the snapshotted value
+      return { previousData }
+    },
+    onError: (err, variables, context) => {
+      // If the mutation fails, use the context returned from onMutate to roll back
+      setOptimisticFavorited(context?.previousData?.isFavorited ?? null)
+    },
+    onSuccess: (data) => {
+      // Update the optimistic state with the actual result
+      setOptimisticFavorited(data.isFavorited)
+    },
+    onSettled: () => {
+      // Always refetch after error or success
+      utils.favorites.check.invalidate({ pokemonId })
+      utils.favorites.list.invalidate()
+    }
+  })
+
+  const handleToggle = async () => {
+    // Check if user is authenticated by trying the mutation
+    try {
+      await toggleFavorite.mutateAsync({
+        pokemonId,
+        pokemonName,
+        pokemonSprite
+      })
+    } catch (error: unknown) {
+      // If unauthorized, call the auth required callback
+      if (
+        error &&
+        typeof error === 'object' &&
+        'data' in error &&
+        error.data &&
+        typeof error.data === 'object' &&
+        'code' in error.data &&
+        error.data.code === 'UNAUTHORIZED' &&
+        onAuthRequired
+      ) {
+        onAuthRequired()
+      }
+    }
+  }
+
+  // Determine the current favorite status
+  const isFavorited = optimisticFavorited ?? checkData?.isFavorited ?? false
+  const isLoading = isCheckingFavorite || toggleFavorite.isPending
+
+  const sizeClasses = {
+    sm: 'h-6 w-6',
+    md: 'h-8 w-8',
+    lg: 'h-10 w-10'
+  }
+
+  const iconSizes = {
+    sm: 'h-3 w-3',
+    md: 'h-4 w-4',
+    lg: 'h-5 w-5'
+  }
+
+  if (variant === 'full') {
+    return (
+      <Button
+        onClick={handleToggle}
+        disabled={isLoading}
+        variant={isFavorited ? 'default' : 'outline'}
+        size="sm"
+        className={`flex items-center space-x-2 ${className}`}
+      >
+        {isLoading ? (
+          <Loader2 className={`${iconSizes[size]} animate-spin`} />
+        ) : (
+          <Heart
+            className={`${iconSizes[size]} ${
+              isFavorited ? 'fill-current text-red-500' : 'text-gray-500'
+            }`}
+          />
+        )}
+        <span>{isFavorited ? 'Favorited' : 'Add to Favorites'}</span>
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      onClick={handleToggle}
+      disabled={isLoading}
+      variant="ghost"
+      size="sm"
+      className={`${sizeClasses[size]} p-0 ${className}`}
+    >
+      {isLoading ? (
+        <Loader2 className={`${iconSizes[size]} animate-spin text-gray-500`} />
+      ) : (
+        <Heart
+          className={`${iconSizes[size]} transition-colors ${
+            isFavorited
+              ? 'fill-current text-red-500 hover:text-red-600'
+              : 'text-gray-400 hover:text-red-500'
+          }`}
+        />
+      )}
+    </Button>
+  )
+}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import Link from 'next/link'
+
+import { LogIn, X } from 'lucide-react'
+
+import { Button } from './ui/button'
+
+interface LoginPromptProps {
+  isOpen: boolean
+  onClose: () => void
+  message?: string
+}
+
+export default function LoginPrompt({
+  isOpen,
+  onClose,
+  message = 'Please log in to save your favorite Pokémon!'
+}: LoginPromptProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black p-4">
+      <div className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        {/* Close Button */}
+        <Button
+          onClick={onClose}
+          variant="ghost"
+          size="sm"
+          className="absolute top-4 right-4 h-8 w-8 p-0"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+
+        {/* Content */}
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+            <LogIn className="h-6 w-6 text-blue-600" />
+          </div>
+
+          <h3 className="mb-2 text-lg font-semibold text-gray-900">Login Required</h3>
+
+          <p className="mb-6 text-sm text-gray-600">{message}</p>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button
+              asChild
+              className="flex-1"
+            >
+              <Link href="/login">
+                <LogIn className="mr-2 h-4 w-4" />
+                Log In
+              </Link>
+            </Button>
+
+            <Button
+              asChild
+              variant="outline"
+              className="flex-1"
+            >
+              <Link href="/register">Sign Up</Link>
+            </Button>
+          </div>
+
+          <Button
+            onClick={onClose}
+            variant="ghost"
+            size="sm"
+            className="mt-4 text-gray-500"
+          >
+            Maybe later
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
+
 import Image from 'next/image'
 
+import FavoriteButton from './FavoriteButton'
+import LoginPrompt from './LoginPrompt'
 import { Card, CardContent } from './ui/card'
 
 interface PokemonCardProps {
@@ -11,6 +15,7 @@ interface PokemonCardProps {
   }
   onClick?: () => void
   priority?: boolean
+  showFavoriteButton?: boolean
 }
 
 const typeColors: Record<string, string> = {
@@ -34,48 +39,87 @@ const typeColors: Record<string, string> = {
   fairy: 'bg-pink-300'
 }
 
-export default function PokemonCard({ pokemon, onClick, priority = false }: PokemonCardProps) {
+export default function PokemonCard({
+  pokemon,
+  onClick,
+  priority = false,
+  showFavoriteButton = true
+}: PokemonCardProps) {
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false)
   const capitalizedName = pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)
 
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation() // Prevent card click
+  }
+
+  const handleAuthRequired = () => {
+    setLoginPromptOpen(true)
+  }
+
   return (
-    <Card
-      className="group cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg"
-      onClick={onClick}
-    >
-      <CardContent className="p-4">
-        <div className="relative mb-3 aspect-square overflow-hidden rounded-lg bg-gray-50">
-          <Image
-            src={pokemon.sprite}
-            alt={pokemon.name}
-            fill
-            className="object-contain p-2 transition-transform duration-200 group-hover:scale-110"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            priority={priority}
-            onError={(e) => {
-              const target = e.target as HTMLImageElement
-              target.src = '/pokeball-placeholder.png'
-            }}
-          />
-        </div>
+    <>
+      <Card
+        className="group cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg"
+        onClick={onClick}
+      >
+        <CardContent className="p-4">
+          <div className="relative mb-3 aspect-square overflow-hidden rounded-lg bg-gray-50">
+            <Image
+              src={pokemon.sprite}
+              alt={pokemon.name}
+              fill
+              className="object-contain p-2 transition-transform duration-200 group-hover:scale-110"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              priority={priority}
+              onError={(e) => {
+                const target = e.target as HTMLImageElement
+                target.src = '/pokeball-placeholder.png'
+              }}
+            />
 
-        <div className="text-center">
-          <p className="mb-1 text-sm text-gray-500">#{pokemon.id.toString().padStart(3, '0')}</p>
-          <h3 className="mb-2 text-lg font-semibold text-gray-900">{capitalizedName}</h3>
-
-          <div className="flex flex-wrap justify-center gap-1">
-            {pokemon.types.map((type) => (
-              <span
-                key={type}
-                className={`rounded-full px-2 py-1 text-xs font-medium text-white ${
-                  typeColors[type] || 'bg-gray-400'
-                }`}
+            {/* Favorite Button */}
+            {showFavoriteButton && (
+              <div
+                className="absolute top-2 right-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+                onClick={handleFavoriteClick}
               >
-                {type.charAt(0).toUpperCase() + type.slice(1)}
-              </span>
-            ))}
+                <FavoriteButton
+                  pokemonId={pokemon.id.toString()}
+                  pokemonName={pokemon.name}
+                  pokemonSprite={pokemon.sprite}
+                  onAuthRequired={handleAuthRequired}
+                  size="sm"
+                />
+              </div>
+            )}
           </div>
-        </div>
-      </CardContent>
-    </Card>
+
+          <div className="text-center">
+            <p className="mb-1 text-sm text-gray-500">#{pokemon.id.toString().padStart(3, '0')}</p>
+            <h3 className="mb-2 text-lg font-semibold text-gray-900">{capitalizedName}</h3>
+
+            <div className="flex flex-wrap justify-center gap-1">
+              {pokemon.types.map((type) => (
+                <span
+                  key={type}
+                  className={`rounded-full px-2 py-1 text-xs font-medium text-white ${
+                    typeColors[type] || 'bg-gray-400'
+                  }`}
+                >
+                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                </span>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Login Prompt */}
+      <LoginPrompt
+        isOpen={loginPromptOpen}
+        onClose={() => setLoginPromptOpen(false)}
+        message="Log in to save your favorite Pokémon!"
+      />
+    </>
   )
 }

--- a/src/components/PokemonDetailModal.tsx
+++ b/src/components/PokemonDetailModal.tsx
@@ -1,11 +1,15 @@
 'use client'
 
+import { useState } from 'react'
+
 import Image from 'next/image'
 
 import { api } from '@/trpc/client'
 import { X } from 'lucide-react'
 
+import FavoriteButton from './FavoriteButton'
 import { PokemonDetailSkeleton } from './LoadingSkeleton'
+import LoginPrompt from './LoginPrompt'
 import { Button } from './ui/button'
 
 interface PokemonDetailModalProps {
@@ -19,6 +23,8 @@ export default function PokemonDetailModal({
   isOpen,
   onClose
 }: PokemonDetailModalProps) {
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false)
+
   const {
     data: pokemon,
     isLoading,
@@ -27,6 +33,10 @@ export default function PokemonDetailModal({
     { nameOrId: pokemonName },
     { enabled: isOpen && !!pokemonName }
   )
+
+  const handleAuthRequired = () => {
+    setLoginPromptOpen(true)
+  }
 
   if (!isOpen) return null
 
@@ -90,6 +100,19 @@ export default function PokemonDetailModal({
         >
           <X className="h-4 w-4" />
         </Button>
+
+        {/* Favorite Button */}
+        {pokemon && (
+          <div className="absolute top-4 right-16 z-10">
+            <FavoriteButton
+              pokemonId={pokemon.id.toString()}
+              pokemonName={pokemon.name}
+              pokemonSprite={pokemon.sprite}
+              onAuthRequired={handleAuthRequired}
+              size="md"
+            />
+          </div>
+        )}
 
         <div className="p-6">
           {isLoading && <PokemonDetailSkeleton />}
@@ -212,6 +235,13 @@ export default function PokemonDetailModal({
           )}
         </div>
       </div>
+
+      {/* Login Prompt */}
+      <LoginPrompt
+        isOpen={loginPromptOpen}
+        onClose={() => setLoginPromptOpen(false)}
+        message="Log in to save your favorite Pokémon!"
+      />
     </div>
   )
 }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,8 +1,10 @@
+import { favoritesRouter } from './routers/favorites'
 import { pokemonRouter } from './routers/pokemon'
 import { createTRPCRouter } from './trpc'
 
 export const appRouter = createTRPCRouter({
-  pokemon: pokemonRouter
+  pokemon: pokemonRouter,
+  favorites: favoritesRouter
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/api/routers/favorites.ts
+++ b/src/server/api/routers/favorites.ts
@@ -1,0 +1,144 @@
+import { favorite } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc'
+
+export const favoritesRouter = createTRPCRouter({
+  // Toggle favorite (add/remove)
+  toggle: protectedProcedure
+    .input(
+      z.object({
+        pokemonId: z.string(),
+        pokemonName: z.string(),
+        pokemonSprite: z.string().optional()
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        // Check if already favorited
+        const existingFavorite = await ctx.db
+          .select()
+          .from(favorite)
+          .where(and(eq(favorite.userId, ctx.userId), eq(favorite.pokemonId, input.pokemonId)))
+          .limit(1)
+
+        if (existingFavorite.length > 0) {
+          // Remove from favorites
+          await ctx.db
+            .delete(favorite)
+            .where(and(eq(favorite.userId, ctx.userId), eq(favorite.pokemonId, input.pokemonId)))
+
+          return {
+            isFavorited: false,
+            action: 'removed'
+          }
+        } else {
+          // Add to favorites
+          await ctx.db.insert(favorite).values({
+            id: crypto.randomUUID(),
+            userId: ctx.userId,
+            pokemonId: input.pokemonId,
+            pokemonName: input.pokemonName,
+            pokemonSprite: input.pokemonSprite
+          })
+
+          return {
+            isFavorited: true,
+            action: 'added'
+          }
+        }
+      } catch (error) {
+        console.error('Failed to toggle favorite:', error)
+        throw new Error('Failed to toggle favorite')
+      }
+    }),
+
+  // Get user's favorites list
+  list: protectedProcedure.query(async ({ ctx }) => {
+    try {
+      const favorites = await ctx.db
+        .select()
+        .from(favorite)
+        .where(eq(favorite.userId, ctx.userId))
+        .orderBy(favorite.createdAt)
+
+      return {
+        favorites: favorites.map((fav) => ({
+          id: fav.pokemonId,
+          name: fav.pokemonName,
+          sprite: fav.pokemonSprite || '/pokeball-placeholder.png',
+          createdAt: fav.createdAt
+        })),
+        count: favorites.length
+      }
+    } catch (error) {
+      console.error('Failed to fetch favorites:', error)
+      throw new Error('Failed to fetch favorites')
+    }
+  }),
+
+  // Check if a Pokemon is favorited
+  check: protectedProcedure
+    .input(z.object({ pokemonId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const existingFavorite = await ctx.db
+          .select()
+          .from(favorite)
+          .where(and(eq(favorite.userId, ctx.userId), eq(favorite.pokemonId, input.pokemonId)))
+          .limit(1)
+
+        return {
+          isFavorited: existingFavorite.length > 0
+        }
+      } catch (error) {
+        console.error('Failed to check favorite status:', error)
+        throw new Error('Failed to check favorite status')
+      }
+    }),
+
+  // Check multiple Pokemon favorite status (for lists)
+  checkMultiple: protectedProcedure
+    .input(z.object({ pokemonIds: z.array(z.string()) }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const favorites = await ctx.db
+          .select({ pokemonId: favorite.pokemonId })
+          .from(favorite)
+          .where(eq(favorite.userId, ctx.userId))
+
+        const favoritedIds = new Set(favorites.map((fav) => fav.pokemonId))
+
+        return input.pokemonIds.reduce(
+          (acc, pokemonId) => {
+            acc[pokemonId] = favoritedIds.has(pokemonId)
+            return acc
+          },
+          {} as Record<string, boolean>
+        )
+      } catch (error) {
+        console.error('Failed to check multiple favorites:', error)
+        throw new Error('Failed to check favorite status')
+      }
+    }),
+
+  // Public endpoint to get favorite count for a Pokemon (optional feature)
+  getCount: publicProcedure
+    .input(z.object({ pokemonId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const count = await ctx.db
+          .select({ count: favorite.pokemonId })
+          .from(favorite)
+          .where(eq(favorite.pokemonId, input.pokemonId))
+
+        return {
+          count: count.length
+        }
+      } catch (error) {
+        console.error('Failed to get favorite count:', error)
+        return { count: 0 }
+      }
+    })
+})


### PR DESCRIPTION
This pull request introduces a complete "Favorites" feature for Pokémon, including a new favorites page, favorite button components, login prompts, and backend API integration. It enables users to add or remove Pokémon from their favorites, view their collection, and prompts for authentication when required. The changes are grouped below by theme.

**Favorites Feature Implementation**

* Added a new `FavoritesPage` at `src/app/favorites/page.tsx` that displays the user's favorite Pokémon, handles loading and error states, and prompts for login if the user is not authenticated.
* Created a reusable `FavoriteButton` component that allows users to optimistically add or remove a Pokémon from their favorites, with authentication checks and UI feedback.
* Added a `LoginPrompt` modal component to prompt users to log in or sign up when attempting to use favorites functionality while unauthenticated.
* Integrated the `FavoriteButton` and `LoginPrompt` into `PokemonCard` and `PokemonDetailModal`, so users can favorite Pokémon from both the card and detail modal views, with proper handling for unauthenticated users. [[1]](diffhunk://#diff-1727fdf2fe3fb3f77d27efae772714fa92918f2f76ec519e4ec9ccbbc6688ef2R1-R6) [[2]](diffhunk://#diff-1727fdf2fe3fb3f77d27efae772714fa92918f2f76ec519e4ec9ccbbc6688ef2R18) [[3]](diffhunk://#diff-1727fdf2fe3fb3f77d27efae772714fa92918f2f76ec519e4ec9ccbbc6688ef2L37-R60) [[4]](diffhunk://#diff-1727fdf2fe3fb3f77d27efae772714fa92918f2f76ec519e4ec9ccbbc6688ef2R79-R94) [[5]](diffhunk://#diff-1727fdf2fe3fb3f77d27efae772714fa92918f2f76ec519e4ec9ccbbc6688ef2R116-R123) [[6]](diffhunk://#diff-d48ef28c05ca40e0cdffba527d1c170f4836ea415620160acf79fb830cc6be5cR3-R12) [[7]](diffhunk://#diff-d48ef28c05ca40e0cdffba527d1c170f4836ea415620160acf79fb830cc6be5cR26-R27) [[8]](diffhunk://#diff-d48ef28c05ca40e0cdffba527d1c170f4836ea415620160acf79fb830cc6be5cR37-R40) [[9]](diffhunk://#diff-d48ef28c05ca40e0cdffba527d1c170f4836ea415620160acf79fb830cc6be5cR104-R116) [[10]](diffhunk://#diff-d48ef28c05ca40e0cdffba527d1c170f4836ea415620160acf79fb830cc6be5cR238-R244)

**Backend Integration**

* Registered the `favoritesRouter` in the TRPC API root, enabling backend support for favorites operations (listing, checking, toggling).